### PR TITLE
Bind @UserId only when it appears in the statement

### DIFF
--- a/Emby.Server.Implementations/Data/SqliteItemRepository.cs
+++ b/Emby.Server.Implementations/Data/SqliteItemRepository.cs
@@ -4934,6 +4934,7 @@ SELECT key FROM UserDatas WHERE isFavorite=@IsFavorite AND userId=@UserId)
 AND Type = @InternalPersonType)");
                 statement?.TryBind("@IsFavorite", query.IsFavorite.Value);
                 statement?.TryBind("@InternalPersonType", typeof(Person).FullName);
+                statement?.TryBind("@UserId", query.User.InternalId);
             }
 
             if (!query.ItemId.Equals(default))
@@ -4986,11 +4987,6 @@ AND Type = @InternalPersonType)");
             {
                 whereClauses.Add("p.Name like @NameContains");
                 statement?.TryBind("@NameContains", "%" + query.NameContains + "%");
-            }
-
-            if (query.User != null)
-            {
-                statement?.TryBind("@UserId", query.User.InternalId);
             }
 
             return whereClauses;


### PR DESCRIPTION
Bind @userid only when it's in the statement

**Changes**
This commit fixes a case where SqliteItemRepository attempts to bind @userid even when such parameter may not appear in the query

**Issues**
https://github.com/jellyfin/jellyfin/issues/8141
